### PR TITLE
Bugfix/permalink spacing

### DIFF
--- a/admin/app/helpers/push_type/admin_helper.rb
+++ b/admin/app/helpers/push_type/admin_helper.rb
@@ -11,5 +11,9 @@ module PushType
       [el, label].compact.join(' ').html_safe
     end
 
+    def node_url(node)
+      "http://#{request.host_with_port}/#{node.parent.permalink + '/' if node.parent}#{node.slug}"
+    end
+
   end
 end

--- a/admin/app/views/push_type/admin/nodes/_form_fields.html.haml
+++ b/admin/app/views/push_type/admin/nodes/_form_fields.html.haml
@@ -15,10 +15,10 @@
               %span.key Permalink
               %span.value
                 %span.show-for-medium-up
-                  = "http://#{request.host_with_port}/#{@node.parent.permalink + '/' if @node.parent}#{@node.slug}"
+                  = node_url(@node)
               %button.button.tiny.radius.secondary{ data: { dropdown: 'slug-field' } } Edit
               - if @node.published?
-                %a.button.tiny.radius{class: "primary", href: "http://#{request.host_with_port}/#{@node.parent.permalink + '/' if @node.parent}#{@node.slug}"}
+                %a.button.tiny.radius{class: "primary", href: node_url(@node)}
                   Live page
               #slug-field.f-dropdown.content{ data: { dropdown: { content: true } } }
                 = f.label :slug

--- a/admin/app/views/push_type/admin/nodes/_form_fields.html.haml
+++ b/admin/app/views/push_type/admin/nodes/_form_fields.html.haml
@@ -14,10 +14,12 @@
             .columns{ :'v-bind:class' => '{visible: node.slug}' }
               %span.key Permalink
               %span.value
-                %span.show-for-medium-up http://#{ request.host_with_port }/
-                = content_tag :span, @node.parent.permalink+'/' if @node.parent
-                %span {{ node.slug }}
+                %span.show-for-medium-up
+                  = "http://#{request.host_with_port}/#{@node.parent.permalink + '/' if @node.parent}#{@node.slug}"
               %button.button.tiny.radius.secondary{ data: { dropdown: 'slug-field' } } Edit
+              - if @node.published?
+                %a.button.tiny.radius{class: "primary", href: "http://#{request.host_with_port}/#{@node.parent.permalink + '/' if @node.parent}#{@node.slug}"}
+                  Live page
               #slug-field.f-dropdown.content{ data: { dropdown: { content: true } } }
                 = f.label :slug
                 = f.text_field :slug, :'v-model' => 'node.slug', :'v-on:keyup' => 'cleanSlug'


### PR DESCRIPTION
This fixes a bug where when selecting the permalink value to copy into the address bar, it would place spaces after the forward slashes and result in having to manually remove the spaces.

This also adds a live page link on the node edit page if it is currently published for easier access to the front-end content